### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/bryamcarmona/fee55683-7587-45f3-8b19-d7d7ac26ceee/836539f6-6a16-4c36-8e71-54a633a016bf/_apis/work/boardbadge/224b5753-db80-46e5-a1f7-d6d2be96c795)](https://dev.azure.com/bryamcarmona/fee55683-7587-45f3-8b19-d7d7ac26ceee/_boards/board/t/836539f6-6a16-4c36-8e71-54a633a016bf/Microsoft.RequirementCategory)
 # Examen_interciclo
 Integrantes: 
 Sebastian Carmona


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#10](https://dev.azure.com/bryamcarmona/fee55683-7587-45f3-8b19-d7d7ac26ceee/_workitems/edit/10). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.